### PR TITLE
[DO NOT MERGE] nrc/run-anywhere-pr1399 — pre-merge carry of nrc-cnrc/EGSnrc#1399

### DIFF
--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -189,6 +189,7 @@ int EGS_AdvancedApplication::initEGSnrcBackEnd() {
     __egs_iovar(64,app_name.size(),app_name.c_str(),the_egsio->user_code);
     __egs_iovar(128,hen_house.size(),hen_house.c_str(),the_egsio->hen_house);
     __egs_iovar(128,egs_home.size(),egs_home.c_str(),the_egsio->egs_home);
+    __egs_iovar(256,output_dir.size(),output_dir.c_str(),the_egsio->output_dir);
     __egs_iovar(256,input_file.size(),input_file.c_str(),the_egsio->input_file);
     __egs_iovar(256,final_output_file.size(),final_output_file.c_str(),
                 the_egsio->output_file);
@@ -1250,7 +1251,7 @@ void EGS_AdvancedApplication::splitTopParticleIsotropically(const EGS_Float &fsp
     the_stack->wt[np] /= fsplit;
     double E = the_stack->E[np];
     EGS_Float x = the_stack->x[np], y = the_stack->y[np], z = the_stack->z[np],
-              wthin = the_stack->wt[np], dnear = the_stack->dnear[np];
+                                                          wthin = the_stack->wt[np], dnear = the_stack->dnear[np];
     EGS_Float u,v,w;
     /* If fsplit is a non-integer, sample between int(fsplit) and int(split)+1 */
     int nsplit = int(fsplit);

--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -272,7 +272,8 @@ EGS_Application::EGS_Application(int argc, char **argv) : input(0), geometry(0),
     //
     // *** check if there is an input file specified on the command line
     //
-    getArgument(argc,argv,"-i","--input",input_file);
+    string input_arg;
+    getArgument(argc,argv,"-i","--input",input_arg);
     //egsFatal("%s\n  no input file specified\n",__egs_app_msg1);
     //
     // *** create the name of the working directory
@@ -280,15 +281,14 @@ EGS_Application::EGS_Application(int argc, char **argv) : input(0), geometry(0),
     char buf[512];
     sprintf(buf,"egsrun_%d_",egsGetPid());
     run_dir = buf;
-    if (input_file.size() > 0) {
-
-        // Remove the .egsinp extension if it was included
-        size_t ext = input_file.rfind(".egsinp");
+    if (input_arg.size() > 0) {
+        // Remove the .egsinp extension if it was included.
+        size_t ext = input_arg.rfind(".egsinp");
         if (ext != std::string::npos) {
-            input_file = input_file.substr(0,ext);
+            input_arg = input_arg.substr(0,ext);
         }
 
-        run_dir += input_file;
+        run_dir += egsStripPath(input_arg);
         run_dir += '_';
     }
     else {
@@ -323,14 +323,45 @@ EGS_Application::EGS_Application(int argc, char **argv) : input(0), geometry(0),
     // *** check if the input file exists.
     //
     string ifile;
-    if (input_file.size() > 0) {
-        ifile = egsJoinPath(app_dir,input_file);
-        if (ifile.find(".egsinp") == string::npos) {
-            ifile += ".egsinp";
+    output_dir = ".";
+    if (input_arg.size() > 0) {
+        bool has_path = input_arg.find('/') != string::npos ||
+                        input_arg.find('\\') != string::npos;
+        auto with_ext = [](const string &s) -> string {
+            return s.find(".egsinp") == string::npos ? s + ".egsinp" : s;
+        };
+        string local_ifile = with_ext(input_arg);
+        if (!EGS_ACCESS(local_ifile.c_str(),R_OK)) {
+            ifile = local_ifile;
         }
-        if (EGS_ACCESS(ifile.c_str(),R_OK))
+        else if (has_path || egsIsAbsolutePath(input_arg)) {
             egsFatal("%s\n  the input file %s does not exist or is not "
-                     "readable\n",__egs_app_msg1,ifile.c_str());
+                     "readable\n",__egs_app_msg1,local_ifile.c_str());
+        }
+        else {
+            string egs_home_ifile = with_ext(egsJoinPath(app_dir,input_arg));
+            if (!EGS_ACCESS(egs_home_ifile.c_str(),R_OK)) {
+                ifile = egs_home_ifile;
+            }
+            else {
+                egsFatal("%s\n  the input file %s does not exist in the "
+                         "current directory or in %s\n",__egs_app_msg1,
+                         local_ifile.c_str(),app_dir.c_str());
+            }
+        }
+
+        input_file = egsStripPath(ifile);
+        size_t ext = input_file.rfind(".egsinp");
+        if (ext != std::string::npos) {
+            input_file = input_file.substr(0,ext);
+        }
+        size_t slash = ifile.find_last_of("/\\");
+        if (slash != string::npos) {
+            output_dir = ifile.substr(0,slash);
+            if (!output_dir.size()) {
+                output_dir = ".";
+            }
+        }
     }
 
     //
@@ -341,6 +372,11 @@ EGS_Application::EGS_Application(int argc, char **argv) : input(0), geometry(0),
     }
     if (!output_file.size()) {
         output_file = "test";
+    }
+    string output_dir_arg;
+    if (getArgument(argc,argv,"-d","--output-dir",output_dir_arg) &&
+            output_dir_arg.size()) {
+        output_dir = output_dir_arg;
     }
     //
     // *** see if a batch run.
@@ -471,7 +507,7 @@ bool EGS_Application::getArgument(int &argc, char **argv,
 
 string EGS_Application::constructIOFileName(const char *extension,
         bool with_run_dir) const {
-    string iofile = with_run_dir ? egsJoinPath(app_dir,run_dir) : app_dir;
+    string iofile = with_run_dir ? egsJoinPath(output_dir,run_dir) : output_dir;
     iofile = egsJoinPath(iofile,output_file);
     if (extension) {
         iofile += extension;
@@ -600,7 +636,7 @@ int EGS_Application::howManyJobsDone() {
 
     for (int i = first_parallel; i < first_parallel + n_parallel; i++) {
         sprintf(buf,"%s_w%d.egsdat",final_output_file.c_str(),i);
-        string dfile = egsJoinPath(app_dir,buf);
+        string dfile = egsJoinPath(output_dir,buf);
         if (fileExists(dfile)) {
             n_of_egsdat++;
         }
@@ -641,7 +677,7 @@ int EGS_Application::combineResults() {
     }
     for (int j=first_parallel; j < first_parallel + n_parallel; j++) {
         sprintf(buf,"%s_w%d.egsdat",final_output_file.c_str(),j);
-        string dfile = egsJoinPath(app_dir,buf);
+        string dfile = egsJoinPath(output_dir,buf);
         ifstream data(dfile.c_str());
         if (data) {
             int err = addState(data);

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -527,6 +527,11 @@ public:
         return app_dir;
     };
 
+    /*! \brief Returns the directory for run output and coordination files */
+    const string &getOutputDir() const {
+        return output_dir;
+    };
+
     /*! \brief Returns the name of the working directory */
     const string &getRunDir() const {
         return run_dir;

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1070,6 +1070,7 @@ protected:
     string  egs_home;           //!< The EGS_HOME directory
     string  hen_house;          //!< The HEN_HOUSE directory
     string  app_dir;            //!< The user code directory
+    string  output_dir;         //!< Directory for output and run artifacts
     string  run_dir;            //!< The working directory during the run
     string  egs_config;         //!< The EGSnrc config
     string  input_file;         //!< The input file name

--- a/HEN_HOUSE/egs++/egs_run_control.cpp
+++ b/HEN_HOUSE/egs++/egs_run_control.cpp
@@ -338,7 +338,7 @@ int EGS_UniformRunControl::startSimulation() {
     if (check_egsdat) {
         char buf[512];
         sprintf(buf,"%s_w%d.egsdat",app->getFinalOutputFile().c_str(), ipar);
-        string datFile = egsJoinPath(app->getAppDir(),buf);
+        string datFile = egsJoinPath(app->getOutputDir(),buf);
         if (remove(datFile.c_str()) == 0) {
             egsWarning("EGS_UniformRunControl: %s deleted\n",
                        datFile.c_str());
@@ -584,7 +584,7 @@ EGS_JCFControl::EGS_JCFControl(EGS_Application *a, int Nbuf) :
 }
 
 bool EGS_JCFControl::createControlFile() {
-    string cfile = egsJoinPath(app->getAppDir(),app->getFinalOutputFile());
+    string cfile = egsJoinPath(app->getOutputDir(),app->getFinalOutputFile());
     cfile += ".lock";
     if (!p->createControlFile(cfile.c_str())) {
         egsWarning("EGS_JCFControl: failed to create or lock the "
@@ -604,7 +604,7 @@ bool EGS_JCFControl::createControlFile() {
 }
 
 bool EGS_JCFControl::openControlFile() {
-    string cfile = egsJoinPath(app->getAppDir(),app->getFinalOutputFile());
+    string cfile = egsJoinPath(app->getOutputDir(),app->getFinalOutputFile());
     cfile += ".lock";
     if (!p->openControlFile(cfile.c_str())) {
         egsWarning("EGS_JCFControl: failed to open the "
@@ -904,7 +904,7 @@ int EGS_JCFControl::finishSimulation() {
     if (njob > 0 || removed_jcf) {
         return 0;
     }
-    string cfile = egsJoinPath(app->getAppDir(),app->getFinalOutputFile());
+    string cfile = egsJoinPath(app->getOutputDir(),app->getFinalOutputFile());
     cfile += ".lock";
 #ifdef WIN32
     int res = _unlink(cfile.c_str());

--- a/HEN_HOUSE/egs++/egs_simple_application.cpp
+++ b/HEN_HOUSE/egs++/egs_simple_application.cpp
@@ -147,6 +147,7 @@ EGS_SimpleApplication::EGS_SimpleApplication(int argc, char **argv) {
     _null_terminate(the_egsio->input_file,256);
     _null_terminate(the_egsio->output_file,256);
     _null_terminate(the_egsio->egs_home,128);
+    _null_terminate(the_egsio->output_dir,256);
     _null_terminate(the_egsio->hen_house,128);
     _null_terminate(the_egsio->pegs_file,256);
     _null_terminate(the_egsio->work_dir,128);
@@ -154,9 +155,10 @@ EGS_SimpleApplication::EGS_SimpleApplication(int argc, char **argv) {
     //
     // ********** Get the content of the input file.
     //
-    string ifile(the_egsio->egs_home);
-    ifile += the_egsio->user_code;
-    ifile += fs;
+    string ifile(the_egsio->output_dir);
+    if (ifile.size() && ifile[ifile.size()-1] != fs) {
+        ifile += fs;
+    }
     ifile += the_egsio->input_file;
     ifile += ".egsinp";
     input = new EGS_Input;

--- a/HEN_HOUSE/gui/egs_gui/egs_run_page.cpp
+++ b/HEN_HOUSE/gui/egs_gui/egs_run_page.cpp
@@ -65,6 +65,8 @@ EGS_RunPage::EGS_RunPage(EGS_ConfigReader *cr,
 
 void EGS_RunPage::make() {
 
+  input_dir = QDir::currentPath();
+
   QVBoxLayout *topl = new QVBoxLayout(this);
   topl->setSpacing(6); topl->setMargin(11);
 
@@ -294,7 +296,13 @@ bool EGS_RunPage::addCommandArguments(QStringList &s) {
     }
 
     if( !input_file->text().isEmpty() ) {
-      s << "-i" << input_file->text();
+      QString ifile = input_file->text();
+      QFileInfo fi(ifile);
+      if( !fi.isAbsolute() && !input_dir.isEmpty() ) {
+          ifile = QDir(input_dir).filePath(ifile);
+      }
+      s << "-i" << ifile;
+      s << "-d" << input_dir;
     }
     return true;
 }
@@ -314,7 +322,12 @@ void EGS_RunPage::startBatchExecution() {
     QString exb = henHouse() + "scripts/run_user_code_batch";
     //args << exb; //run_batch->addArgument(exb);
     args << user_code; //run_batch->addArgument(user_code);
-    args << input_file->text(); //run_batch->addArgument(input_file->text());
+    QString ifile = input_file->text();
+    QFileInfo fi(ifile);
+    if( !fi.isAbsolute() && !input_dir.isEmpty() ) {
+        ifile = QDir(input_dir).filePath(ifile);
+    }
+    args << ifile; //run_batch->addArgument(input_file->text());
     if (!pegsless->isChecked()){
        QString pfile; QString look_in = look_for_pegs->currentText();
        QChar ss = QDir::separator();
@@ -335,6 +348,8 @@ void EGS_RunPage::startBatchExecution() {
     args << queue->currentText();//run_batch->addArgument(queue->currentText());
     QString the_qs = "batch="; the_qs += queue_system->currentText();
     args << the_qs;//run_batch->addArgument(the_qs);
+    QString outdir = "outdir="; outdir += input_dir;
+    args << outdir;
     if( njob->value() > 1 ) {
         QString p = "p="; p += njob->text();
         args << p;//run_batch->addArgument(p);
@@ -360,6 +375,7 @@ void EGS_RunPage::startBatchExecution() {
             args << *it;//run_batch->addArgument(*it);
     }
 
+    run_batch->setWorkingDirectory(input_dir);
     run_batch->start(exb,args);
     //if( !run_batch->start() )
     if(run_batch->error()==QProcess::FailedToStart)
@@ -410,6 +426,7 @@ void EGS_RunPage::startExecution() {
   qWarning("Executing: <%s>",args.join(" ").toLatin1().data());
 
   //if( !run->start() )
+  run->setWorkingDirectory(input_dir);
   run->start(exe,args);
   if(run->error()==QProcess::FailedToStart)
     QMessageBox::critical(this,"Error","Failed to start user code",1,0);
@@ -588,14 +605,17 @@ void EGS_RunPage::selectInputFile() {
 #ifdef RP_DEBUG
   qDebug("In EGS_RunPage::selectInputFile()");
 #endif
-  QString start_dir = egsHome() + user_code;
+  QString start_dir = input_dir;
+  if( start_dir.isEmpty() ) start_dir = QDir::currentPath();
   QString s = QFileDialog::getOpenFileName(this,tr("Select input file"),
                                            start_dir, tr("EGS input files (*.egsinp)"));
 #ifdef RP_DEBUG
   qDebug("file: %s",s.toLatin1().data());
 #endif
   if( !s.isEmpty() ) {
-    QFileInfo fi(s); input_file->setText(fi.baseName());
+    QFileInfo fi(s);
+    input_file->setText(fi.baseName());
+    input_dir = fi.absolutePath();
   }
 }
 

--- a/HEN_HOUSE/gui/egs_gui/egs_run_page.h
+++ b/HEN_HOUSE/gui/egs_gui/egs_run_page.h
@@ -113,6 +113,7 @@ private:
 
   QString      user_code;
   QString      target;
+  QString      input_dir;
 
   QString      batch_command;
   QString      generic_bo;

--- a/HEN_HOUSE/interface/egs_interface1.h
+++ b/HEN_HOUSE/interface/egs_interface1.h
@@ -105,38 +105,38 @@
   The mortran common block can be accessed via #the_stack.
  */
 struct EGS_Stack {
-  /*! Array with particle energies in MeV including rest energy */
-  double    E[MXSTACK];
-  /*! Arrays with particle x-positions in cartesian coordinates */
-  EGS_Float x[MXSTACK];
-  /*! Arrays with particle y-positions in cartesian coordinates */
-  EGS_Float y[MXSTACK];
-  /*! Arrays with particle z-positions in cartesian coordinates */
-  EGS_Float z[MXSTACK];
-  /*! Arrays with particle x- direction cosines */
-  EGS_Float u[MXSTACK];
-  /*! Arrays with particle y- direction cosines */
-  EGS_Float v[MXSTACK];
-  /*! Arrays with particle z- direction cosines */
-  EGS_Float w[MXSTACK];
-  /*! Array with nearest distances to a boundary */
-  EGS_Float dnear[MXSTACK];
-  /*! Array with statistical weights */
-  EGS_Float wt[MXSTACK];
-  /*! Particle charges */
-  EGS_I32   iq[MXSTACK];
-  /*! Particle geometry regions */
-  EGS_I32   ir[MXSTACK];
-  /*! Latch variables. Can be used to store some additional information
-      about the particles used at run time
-   */
-  EGS_I32   latch[MXSTACK];
-  /*! The initial particle latch variable */
-  EGS_I32   latchi;
-  /*! Number of particles currently on the stack */
-  EGS_I32   np;
-  /*! Number of particles on the stack before the last interaction occured */
-  EGS_I32   npold;
+    /*! Array with particle energies in MeV including rest energy */
+    double    E[MXSTACK];
+    /*! Arrays with particle x-positions in cartesian coordinates */
+    EGS_Float x[MXSTACK];
+    /*! Arrays with particle y-positions in cartesian coordinates */
+    EGS_Float y[MXSTACK];
+    /*! Arrays with particle z-positions in cartesian coordinates */
+    EGS_Float z[MXSTACK];
+    /*! Arrays with particle x- direction cosines */
+    EGS_Float u[MXSTACK];
+    /*! Arrays with particle y- direction cosines */
+    EGS_Float v[MXSTACK];
+    /*! Arrays with particle z- direction cosines */
+    EGS_Float w[MXSTACK];
+    /*! Array with nearest distances to a boundary */
+    EGS_Float dnear[MXSTACK];
+    /*! Array with statistical weights */
+    EGS_Float wt[MXSTACK];
+    /*! Particle charges */
+    EGS_I32   iq[MXSTACK];
+    /*! Particle geometry regions */
+    EGS_I32   ir[MXSTACK];
+    /*! Latch variables. Can be used to store some additional information
+        about the particles used at run time
+     */
+    EGS_I32   latch[MXSTACK];
+    /*! The initial particle latch variable */
+    EGS_I32   latchi;
+    /*! Number of particles currently on the stack */
+    EGS_I32   np;
+    /*! Number of particles on the stack before the last interaction occured */
+    EGS_I32   npold;
 };
 
 /*! \brief A structure corresponding to the EGSnrc transport threshold
@@ -229,55 +229,55 @@ struct EGS_Thresh {
     for user scoring and for interacting with the user geometry
  */
 struct EGS_Epcont {
-  /*! Energy being deposited locally (may be several depositions) */
-  double    edep;
-  /*! A single sub-threshold energy deposition */
-  double    edep_local;
-  /*! Step length to an interaction */
-  EGS_Float tstep;
-  /*! Step length after step-size restrictions */
-  EGS_Float tustep;
-  /*! Straight line distance between initial and final position without
-      geometry constraints */
-  EGS_Float ustep;
-  /*! Curved transport distance after geometry constraints */
-  EGS_Float tvstep;
-  /*! Straight line transport distance after geometry constraints */
-  EGS_Float vstep;
-  /*! Ratio of mass density in current region to the default mass density
-      of the medium filling the region */
-  EGS_Float rhof;
-  /*! Old particle energy */
-  EGS_Float eold;
-  /*! New particle energy */
-  EGS_Float enew;
-  /*! Electron kinetic energy */
-  EGS_Float eke;
-  /*! ln(eke) */
-  EGS_Float elke;
-  /*! ln(photon energy) */
-  EGS_Float gle;
-  /*! Electron range to \c AE in the current medium */
-  EGS_Float e_range;
-  /*! Position of the particle after the step */
-  EGS_Float x_final, y_final, z_final;
-  /*! Direction of the particle after the step,
-      only set for electrons/positrons */
-  EGS_Float u_final, v_final, w_final;
-  /*! Should the particle be discarded ?
-      - 0 means no discard
-      - >0 means discard immediately
-      - <0 means discard after the step.
+    /*! Energy being deposited locally (may be several depositions) */
+    double    edep;
+    /*! A single sub-threshold energy deposition */
+    double    edep_local;
+    /*! Step length to an interaction */
+    EGS_Float tstep;
+    /*! Step length after step-size restrictions */
+    EGS_Float tustep;
+    /*! Straight line distance between initial and final position without
+        geometry constraints */
+    EGS_Float ustep;
+    /*! Curved transport distance after geometry constraints */
+    EGS_Float tvstep;
+    /*! Straight line transport distance after geometry constraints */
+    EGS_Float vstep;
+    /*! Ratio of mass density in current region to the default mass density
+        of the medium filling the region */
+    EGS_Float rhof;
+    /*! Old particle energy */
+    EGS_Float eold;
+    /*! New particle energy */
+    EGS_Float enew;
+    /*! Electron kinetic energy */
+    EGS_Float eke;
+    /*! ln(eke) */
+    EGS_Float elke;
+    /*! ln(photon energy) */
+    EGS_Float gle;
+    /*! Electron range to \c AE in the current medium */
+    EGS_Float e_range;
+    /*! Position of the particle after the step */
+    EGS_Float x_final, y_final, z_final;
+    /*! Direction of the particle after the step,
+        only set for electrons/positrons */
+    EGS_Float u_final, v_final, w_final;
+    /*! Should the particle be discarded ?
+        - 0 means no discard
+        - >0 means discard immediately
+        - <0 means discard after the step.
 
-      Typically set by the geometry routines.
-  */
-  EGS_I32   idisc;
-  /*! Old geometry region */
-  EGS_I32   irold;
-  /*! New geometry region */
-  EGS_I32   irnew;
-  /*! Array of flags for calls to \c %ausgab() */
-  EGS_I32   iausfl[MXAUS];
+        Typically set by the geometry routines.
+    */
+    EGS_I32   idisc;
+    /*! Old geometry region */
+    EGS_I32   irold;
+    /*! New geometry region */
+    EGS_I32   irnew;
+    /*! Array of flags for calls to \c %ausgab() */
+    EGS_I32   iausfl[MXAUS];
 };
 
 /*! \brief A structure corresponding to the \c ET_control common block.
@@ -346,15 +346,15 @@ struct EGS_Rayleigh {
   index, etc.
 */
 struct EGS_Useful {
-  double    pzero,      //!< Precise zero
-            prm,        //!< Precise electron rest energy in MeV
-            prmt2;      //!< 2*prm
-  EGS_Float rm,         //!< Electron rest energy
-            rhor,       //!< Mass density ratio
-            rhor_new;   //!< Mass density ratio in the new region
-  EGS_I32   medium,     //!< Current medium
-            medium_new, //!< Medium in the new region
-            medold;     //!< Old medium
+    double    pzero,      //!< Precise zero
+              prm,        //!< Precise electron rest energy in MeV
+              prmt2;      //!< 2*prm
+    EGS_Float rm,         //!< Electron rest energy
+              rhor,       //!< Mass density ratio
+              rhor_new;   //!< Mass density ratio in the new region
+    EGS_I32   medium,     //!< Current medium
+              medium_new, //!< Medium in the new region
+              medold;     //!< Old medium
 };
 
 /*! \brief A structure corresponding to the \c xsection_options common block
@@ -386,154 +386,154 @@ struct EGS_Useful {
 */
 struct EGS_XOptions {
 
-  /*! Determines the angular distribution of bremstrahlung. If set to
-    2, Eq. 2BS of the review article by Koch and Motz will be used. If set
-    to 1, the leading term of 2BS will be used (the default).
-    If set to zero, the photons
-    will inherit the direction of the electron so that the user can
-    implement their own angular distribution by calling \c %ausgab() after
-    the bremsstrahlung event and setting the angles of the photons.
-
-    Can be set in the input file using
-    \verbatim
-    Brems angular sampling= Simple or KM
-    \endverbatim
-  */
-  EGS_I32   ibrdst;
-
-  /*! Determines the angular distribution of pair particles. If set to 2,
-    the Schiff formula will be used (Eq. 3D-2003 of the review article by
-    Motz, Olsen and Koch), if set to 1 the leading term of the Schiff formula
-    will be used (the default), if set to 0 the original EGS4 approach
-    of polar angle = ratio of rest energy to total energy is employed.
-
-    Can be set in the input file using
-    \verbatim
-    Pair angular samplin= Off or Simple or KM
-    \endverbatim
-  */
-  EGS_I32   iprdst;
-
-  /*! Determines the bremsstrahlung cross sections differential in the
-    photon energy to be used for sampling the photon energy.
-    If set to 0, the Bethe-Heitler high energy approximation will be
-    used, if set to 1 the NIST tabulations provided by Steve Seltzer
-    will be employed. Default is 0.
-
-    Can be set in the input file using
-    \verbatim
-    Brems cross sections= BH or NIST
-    \endverbatim
-  */
-  EGS_I32   ibr_nist;
-
-  /*! Determines if spin effects will be taken into account in electron
-    and positron elastic scattering (1=yes, the default, 0=no)
-
-    Can be set in the input file using
-    \verbatim
-    Spin effects= On or Off
-    \endverbatim
-   */
-  EGS_I32   spin_effects;
-
-  /*! Bound Compton scattering flag. If set to 0, Compton scattering will
-    be modeled according to Klein-Nishina, if set to 1 (the default),
-    Compton scattering will be modeled according to the relativistic
-    impulse approximation that takes into account binding and
-    Doppler broadenning.
-
-    Can be set in the input file using
-    \verbatim
-    Bound Compton scattering= On or Off
-    \endverbatim
-  */
-  EGS_I32   ibcmp;
-
-  /*! Reyleigh scattering flag. If set to 0 (the default), no
-    Reyleigh scattering will be done. Note that if you turn on
-    Reyleigh scattering by setting this flag to 1, all PEGS4 data
-    sets must include Reyleigh data
-
-    Can be set in the input file using
-    \verbatim
-    Reyleigh scattering= On or Off
-    \endverbatim
-  */
-  EGS_I32   iraylr;
-
-  /*! Atomic relaxations flag. If set to 1 (the default), vacancies
-   created in shells with binding energies above 1 keV will be relaxed
-   by fluorscent, Auger and Coster-Kronig transitions. Vacancies
-   can be currently created after photo-absorption, bound Compton scattering
-   and electron inelastic scattering (if eii_flag is not 0).
-   If set to 0, the binding energy will be given to the photo-electron
-   or deposited locally.
-   */
-  EGS_I32   iedgfl;
-
-  /*! Determines the angular distribution of photo-electrons. If set to
-    1 (the default), the angle of photo-electrons will be sampled from
-    the Sauter distribution. If set to 0, photo-electrons inherit the
-    direction of the incident photon.
-
-    Can be set in the input file using
-    \verbatim
-    Atomic relaxations= On or Off
-    \endverbatim
-  */
-  EGS_I32   iphter;
-
-  /*! Pair cross sections flag. If set to 0 (the default), the energy
-    of the pair particles will be sampled from the first Born approximation
-    cross section in its high-energy appoximation derived by Bethe-Heitler.
-    If set to 1, energies will be sampled from the NRC tabulations
-    based on the exact cross sections (tabulations are available
-    up to 85 MeV, above 85 MeV the Bethe-Heitler cross sections are
-    very close to the exact cross sections).
-
-    Can be set in the input file using
-    \verbatim
-    Pair cross sections= BH or NRC
-    \endverbatim
-  */
-  EGS_I32   pair_nrc;
-
-  /*! Triplet production flag. If set to 0 (the default), triplet events
-    will be simulated as pair events. If set to 1, triplet event will
-    be explicitely simulated using the Borsellino cross section
-
-    Can be set in the input file using
-    \verbatim
-    Triplet production= On or Off
-    \endverbatim
-  */
-  EGS_I32   itriplet;
-
-  /*! Flag for radiative corrections for Compton scattering.
-      If set to 0 (the default), Compton scattering is modelled according
-      to Klein-Nishina or RIA, depending on ibcmp. If set to 1 and
-      rad_compton.mortran is compiled with the other EGSnrc mortran sources,
-      radiative corrections are taken into account in next-to-leading
-      order.
+    /*! Determines the angular distribution of bremstrahlung. If set to
+      2, Eq. 2BS of the review article by Koch and Motz will be used. If set
+      to 1, the leading term of 2BS will be used (the default).
+      If set to zero, the photons
+      will inherit the direction of the electron so that the user can
+      implement their own angular distribution by calling \c %ausgab() after
+      the bremsstrahlung event and setting the angles of the photons.
 
       Can be set in the input file using
       \verbatim
-      Radiative Compton corrections= On or Off
+      Brems angular sampling= Simple or KM
       \endverbatim
-                    */
-  EGS_I32   radc_flag;
+    */
+    EGS_I32   ibrdst;
 
-  /*! Electron impact ionization (EII) flag. If set to 0 (the default),
-   no EII occurs. If set to 1, EII is simulated using cross sections
-   based on unpublished work by Kawrakow
+    /*! Determines the angular distribution of pair particles. If set to 2,
+      the Schiff formula will be used (Eq. 3D-2003 of the review article by
+      Motz, Olsen and Koch), if set to 1 the leading term of the Schiff formula
+      will be used (the default), if set to 0 the original EGS4 approach
+      of polar angle = ratio of rest energy to total energy is employed.
 
-    Can be set in the input file using
-    \verbatim
-    Electron Impact Ionization= On or Off
-    \endverbatim
-   */
-  EGS_I32   eii_flag;
+      Can be set in the input file using
+      \verbatim
+      Pair angular samplin= Off or Simple or KM
+      \endverbatim
+    */
+    EGS_I32   iprdst;
+
+    /*! Determines the bremsstrahlung cross sections differential in the
+      photon energy to be used for sampling the photon energy.
+      If set to 0, the Bethe-Heitler high energy approximation will be
+      used, if set to 1 the NIST tabulations provided by Steve Seltzer
+      will be employed. Default is 0.
+
+      Can be set in the input file using
+      \verbatim
+      Brems cross sections= BH or NIST
+      \endverbatim
+    */
+    EGS_I32   ibr_nist;
+
+    /*! Determines if spin effects will be taken into account in electron
+      and positron elastic scattering (1=yes, the default, 0=no)
+
+      Can be set in the input file using
+      \verbatim
+      Spin effects= On or Off
+      \endverbatim
+     */
+    EGS_I32   spin_effects;
+
+    /*! Bound Compton scattering flag. If set to 0, Compton scattering will
+      be modeled according to Klein-Nishina, if set to 1 (the default),
+      Compton scattering will be modeled according to the relativistic
+      impulse approximation that takes into account binding and
+      Doppler broadenning.
+
+      Can be set in the input file using
+      \verbatim
+      Bound Compton scattering= On or Off
+      \endverbatim
+    */
+    EGS_I32   ibcmp;
+
+    /*! Reyleigh scattering flag. If set to 0 (the default), no
+      Reyleigh scattering will be done. Note that if you turn on
+      Reyleigh scattering by setting this flag to 1, all PEGS4 data
+      sets must include Reyleigh data
+
+      Can be set in the input file using
+      \verbatim
+      Reyleigh scattering= On or Off
+      \endverbatim
+    */
+    EGS_I32   iraylr;
+
+    /*! Atomic relaxations flag. If set to 1 (the default), vacancies
+     created in shells with binding energies above 1 keV will be relaxed
+     by fluorscent, Auger and Coster-Kronig transitions. Vacancies
+     can be currently created after photo-absorption, bound Compton scattering
+     and electron inelastic scattering (if eii_flag is not 0).
+     If set to 0, the binding energy will be given to the photo-electron
+     or deposited locally.
+     */
+    EGS_I32   iedgfl;
+
+    /*! Determines the angular distribution of photo-electrons. If set to
+      1 (the default), the angle of photo-electrons will be sampled from
+      the Sauter distribution. If set to 0, photo-electrons inherit the
+      direction of the incident photon.
+
+      Can be set in the input file using
+      \verbatim
+      Atomic relaxations= On or Off
+      \endverbatim
+    */
+    EGS_I32   iphter;
+
+    /*! Pair cross sections flag. If set to 0 (the default), the energy
+      of the pair particles will be sampled from the first Born approximation
+      cross section in its high-energy appoximation derived by Bethe-Heitler.
+      If set to 1, energies will be sampled from the NRC tabulations
+      based on the exact cross sections (tabulations are available
+      up to 85 MeV, above 85 MeV the Bethe-Heitler cross sections are
+      very close to the exact cross sections).
+
+      Can be set in the input file using
+      \verbatim
+      Pair cross sections= BH or NRC
+      \endverbatim
+    */
+    EGS_I32   pair_nrc;
+
+    /*! Triplet production flag. If set to 0 (the default), triplet events
+      will be simulated as pair events. If set to 1, triplet event will
+      be explicitely simulated using the Borsellino cross section
+
+      Can be set in the input file using
+      \verbatim
+      Triplet production= On or Off
+      \endverbatim
+    */
+    EGS_I32   itriplet;
+
+    /*! Flag for radiative corrections for Compton scattering.
+        If set to 0 (the default), Compton scattering is modelled according
+        to Klein-Nishina or RIA, depending on ibcmp. If set to 1 and
+        rad_compton.mortran is compiled with the other EGSnrc mortran sources,
+        radiative corrections are taken into account in next-to-leading
+        order.
+
+        Can be set in the input file using
+        \verbatim
+        Radiative Compton corrections= On or Off
+        \endverbatim
+                      */
+    EGS_I32   radc_flag;
+
+    /*! Electron impact ionization (EII) flag. If set to 0 (the default),
+     no EII occurs. If set to 1, EII is simulated using cross sections
+     based on unpublished work by Kawrakow
+
+      Can be set in the input file using
+      \verbatim
+      Electron Impact Ionization= On or Off
+      \endverbatim
+     */
+    EGS_I32   eii_flag;
 };
 
 /*! \brief A structure corresponding to the \c egs_vr common block
@@ -604,6 +604,7 @@ struct EGS_IO {
     char pegs_file[256];
     char hen_house[128];
     char egs_home[128];
+    char output_dir[256];
     char work_dir[128];
     char host_name[64];
     EGS_I32 n_parallel, i_parallel, first_parallel, n_max_parallel,

--- a/HEN_HOUSE/interface/egs_interface2.h
+++ b/HEN_HOUSE/interface/egs_interface2.h
@@ -106,38 +106,38 @@
   The mortran common block can be accessed via #the_stack.
  */
 struct EGS_Stack {
-  /*! Array with particle energies in MeV including rest energy */
-  double    E[MXSTACK];
-  /*! Arrays with particle x-positions in cartesian coordinates */
-  EGS_Float x[MXSTACK];
-  /*! Arrays with particle y-positions in cartesian coordinates */
-  EGS_Float y[MXSTACK];
-  /*! Arrays with particle z-positions in cartesian coordinates */
-  EGS_Float z[MXSTACK];
-  /*! Arrays with particle x- direction cosines */
-  EGS_Float u[MXSTACK];
-  /*! Arrays with particle y- direction cosines */
-  EGS_Float v[MXSTACK];
-  /*! Arrays with particle z- direction cosines */
-  EGS_Float w[MXSTACK];
-  /*! Array with nearest distances to a boundary */
-  EGS_Float dnear[MXSTACK];
-  /*! Array with statistical weights */
-  EGS_Float wt[MXSTACK];
-  /*! Particle charges */
-  EGS_I32   iq[MXSTACK];
-  /*! Particle geometry regions */
-  EGS_I32   ir[MXSTACK];
-  /*! Latch variables. Can be used to store some additional information
-      about the particles used at run time
-   */
-  EGS_I32   latch[MXSTACK];
-  /*! The initial particle latch variable */
-  EGS_I32   latchi;
-  /*! Number of particles currently on the stack */
-  EGS_I32   np;
-  /*! Number of particles on the stack before the last interaction occured */
-  EGS_I32   npold;
+    /*! Array with particle energies in MeV including rest energy */
+    double    E[MXSTACK];
+    /*! Arrays with particle x-positions in cartesian coordinates */
+    EGS_Float x[MXSTACK];
+    /*! Arrays with particle y-positions in cartesian coordinates */
+    EGS_Float y[MXSTACK];
+    /*! Arrays with particle z-positions in cartesian coordinates */
+    EGS_Float z[MXSTACK];
+    /*! Arrays with particle x- direction cosines */
+    EGS_Float u[MXSTACK];
+    /*! Arrays with particle y- direction cosines */
+    EGS_Float v[MXSTACK];
+    /*! Arrays with particle z- direction cosines */
+    EGS_Float w[MXSTACK];
+    /*! Array with nearest distances to a boundary */
+    EGS_Float dnear[MXSTACK];
+    /*! Array with statistical weights */
+    EGS_Float wt[MXSTACK];
+    /*! Particle charges */
+    EGS_I32   iq[MXSTACK];
+    /*! Particle geometry regions */
+    EGS_I32   ir[MXSTACK];
+    /*! Latch variables. Can be used to store some additional information
+        about the particles used at run time
+     */
+    EGS_I32   latch[MXSTACK];
+    /*! The initial particle latch variable */
+    EGS_I32   latchi;
+    /*! Number of particles currently on the stack */
+    EGS_I32   np;
+    /*! Number of particles on the stack before the last interaction occured */
+    EGS_I32   npold;
 };
 
 /*! \brief A structure corresponding to the EGSnrc transport threshold
@@ -230,55 +230,55 @@ struct EGS_Thresh {
     for user scoring and for interacting with the user geometry
  */
 struct EGS_Epcont {
-  /*! Energy being deposited locally (may be several depositions) */
-  double    edep;
-  /*! A single sub-threshold energy deposition */
-  double    edep_local;
-  /*! Step length to an interaction */
-  EGS_Float tstep;
-  /*! Step length after step-size restrictions */
-  EGS_Float tustep;
-  /*! Straight line distance between initial and final position without
-      geometry constraints */
-  EGS_Float ustep;
-  /*! Curved transport distance after geometry constraints */
-  EGS_Float tvstep;
-  /*! Straight line transport distance after geometry constraints */
-  EGS_Float vstep;
-  /*! Ratio of mass density in current region to the default mass density
-      of the medium filling the region */
-  EGS_Float rhof;
-  /*! Old particle energy */
-  EGS_Float eold;
-  /*! New particle energy */
-  EGS_Float enew;
-  /*! Electron kinetic energy */
-  EGS_Float eke;
-  /*! ln(eke) */
-  EGS_Float elke;
-  /*! ln(photon energy) */
-  EGS_Float gle;
-  /*! Electron range to \c AE in the current medium */
-  EGS_Float e_range;
-  /*! Position of the particle after the step */
-  EGS_Float x_final, y_final, z_final;
-  /*! Direction of the particle after the step,
-      only set for electrons/positrons */
-  EGS_Float u_final, v_final, w_final;
-  /*! Should the particle be discarded ?
-      - 0 means no discard
-      - >0 means discard immediately
-      - <0 means discard after the step.
+    /*! Energy being deposited locally (may be several depositions) */
+    double    edep;
+    /*! A single sub-threshold energy deposition */
+    double    edep_local;
+    /*! Step length to an interaction */
+    EGS_Float tstep;
+    /*! Step length after step-size restrictions */
+    EGS_Float tustep;
+    /*! Straight line distance between initial and final position without
+        geometry constraints */
+    EGS_Float ustep;
+    /*! Curved transport distance after geometry constraints */
+    EGS_Float tvstep;
+    /*! Straight line transport distance after geometry constraints */
+    EGS_Float vstep;
+    /*! Ratio of mass density in current region to the default mass density
+        of the medium filling the region */
+    EGS_Float rhof;
+    /*! Old particle energy */
+    EGS_Float eold;
+    /*! New particle energy */
+    EGS_Float enew;
+    /*! Electron kinetic energy */
+    EGS_Float eke;
+    /*! ln(eke) */
+    EGS_Float elke;
+    /*! ln(photon energy) */
+    EGS_Float gle;
+    /*! Electron range to \c AE in the current medium */
+    EGS_Float e_range;
+    /*! Position of the particle after the step */
+    EGS_Float x_final, y_final, z_final;
+    /*! Direction of the particle after the step,
+        only set for electrons/positrons */
+    EGS_Float u_final, v_final, w_final;
+    /*! Should the particle be discarded ?
+        - 0 means no discard
+        - >0 means discard immediately
+        - <0 means discard after the step.
 
-      Typically set by the geometry routines.
-  */
-  EGS_I32   idisc;
-  /*! Old geometry region */
-  EGS_I32   irold;
-  /*! New geometry region */
-  EGS_I32   irnew;
-  /*! Array of flags for calls to \c %ausgab() */
-  EGS_I32   iausfl[MXAUS];
+        Typically set by the geometry routines.
+    */
+    EGS_I32   idisc;
+    /*! Old geometry region */
+    EGS_I32   irold;
+    /*! New geometry region */
+    EGS_I32   irnew;
+    /*! Array of flags for calls to \c %ausgab() */
+    EGS_I32   iausfl[MXAUS];
 };
 
 /*! \brief A structure corresponding to the \c ET_control common block.
@@ -349,15 +349,15 @@ struct EGS_Rayleigh {
   index, etc.
 */
 struct EGS_Useful {
-  double    pzero,      //!< Precise zero
-            prm,        //!< Precise electron rest energy in MeV
-            prmt2;      //!< 2*prm
-  EGS_Float rm,         //!< Electron rest energy
-            rhor,       //!< Mass density ratio
-            rhor_new;   //!< Mass density ratio in the new region
-  EGS_I32   medium,     //!< Current medium
-            medium_new, //!< Medium in the new region
-            medold;     //!< Old medium
+    double    pzero,      //!< Precise zero
+              prm,        //!< Precise electron rest energy in MeV
+              prmt2;      //!< 2*prm
+    EGS_Float rm,         //!< Electron rest energy
+              rhor,       //!< Mass density ratio
+              rhor_new;   //!< Mass density ratio in the new region
+    EGS_I32   medium,     //!< Current medium
+              medium_new, //!< Medium in the new region
+              medold;     //!< Old medium
 };
 
 /*! \brief A structure corresponding to the \c xsection_options common block
@@ -389,156 +389,156 @@ struct EGS_Useful {
 */
 struct EGS_XOptions {
 
-  /*! Determines the angular distribution of bremstrahlung. If set to
-    2, Eq. 2BS of the review article by Koch and Motz will be used. If set
-    to 1, the leading term of 2BS will be used (the default).
-    If set to zero, the photons
-    will inherit the direction of the electron so that the user can
-    implement their own angular distribution by calling \c %ausgab() after
-    the bremsstrahlung event and setting the angles of the photons.
-
-    Can be set in the input file using
-    \verbatim
-    Brems angular sampling= Simple or KM
-    \endverbatim
-  */
-  EGS_I32   ibrdst;
-
-  /*! Determines the angular distribution of pair particles. If set to 2,
-    the Schiff formula will be used (Eq. 3D-2003 of the review article by
-    Motz, Olsen and Koch), if set to 1 the leading term of the Schiff formula
-    will be used (the default), if set to 0 the original EGS4 approach
-    of polar angle = ratio of rest energy to total energy is employed.
-
-    Can be set in the input file using
-    \verbatim
-    Pair angular sampling= Off or Simple or KM
-    \endverbatim
-  */
-  EGS_I32   iprdst;
-
-  /*! Determines the bremsstrahlung cross sections differential in the
-    photon energy to be used for sampling the photon energy.
-    If set to 0, the Bethe-Heitler high energy approximation will be
-    used. If set to 1, the NIST tabulations provided by Steve Seltzer
-    will be employed. If set to 2, the NRC brems data will be used,
-    which is a modified version of the NIST data with corrected
-    electron-electron brems contributions. Default is 0.
-
-    Can be set in the input file using
-    \verbatim
-    Brems cross sections= BH or NIST or NRC
-    \endverbatim
-  */
-  EGS_I32   ibr_nist;
-
-  /*! Determines if spin effects will be taken into account in electron
-    and positron elastic scattering (1=yes, the default, 0=no)
-
-    Can be set in the input file using
-    \verbatim
-    Spin effects= On or Off
-    \endverbatim
-   */
-  EGS_I32   spin_effects;
-
-  /*! Bound Compton scattering flag. If set to 0, Compton scattering will
-    be modeled according to Klein-Nishina, if set to 1 (the default),
-    Compton scattering will be modeled according to the relativistic
-    impulse approximation that takes into account binding and
-    Doppler broadenning.
-
-    Can be set in the input file using
-    \verbatim
-    Bound Compton scattering= On or Off
-    \endverbatim
-  */
-  EGS_I32   ibcmp;
-
-  /*! Reyleigh scattering flag. If set to 0 (the default), no
-    Reyleigh scattering will be done. Note that if you turn on
-    Reyleigh scattering by setting this flag to 1, all PEGS4 data
-    sets must include Reyleigh data
-
-    Can be set in the input file using
-    \verbatim
-    Reyleigh scattering= On or Off
-    \endverbatim
-  */
-  EGS_I32 iraylr;
-
-  /*! Atomic relaxations flag. If set to 1 (the default), vacancies
-   created in shells with binding energies above 1 keV will be relaxed
-   by fluorescent, Auger and Coster-Kronig transitions. Vacancies
-   can be currently created after photo-absorption, bound Compton scattering
-   and electron inelastic scattering (if eii_flag is not 0).
-   If set to 0, the binding energy will be given to the photo-electron
-   or deposited locally.
-   */
-  EGS_I32   iedgfl;
-
-  /*! Determines the angular distribution of photo-electrons. If set to
-    1 (the default), the angle of photo-electrons will be sampled from
-    the Sauter distribution. If set to 0, photo-electrons inherit the
-    direction of the incident photon.
-
-    Can be set in the input file using
-    \verbatim
-    Atomic relaxations= On or Off
-    \endverbatim
-  */
-  EGS_I32   iphter;
-
-  /*! Pair cross sections flag. If set to 0 (the default), the energy
-    of the pair particles will be sampled from the first Born approximation
-    cross section in its high-energy appoximation derived by Bethe-Heitler.
-    If set to 1, energies will be sampled from the NRC tabulations
-    based on the exact cross sections (tabulations are available
-    up to 85 MeV, above 85 MeV the Bethe-Heitler cross sections are
-    very close to the exact cross sections).
-
-    Can be set in the input file using
-    \verbatim
-    Pair cross sections= BH or NRC
-    \endverbatim
-  */
-  EGS_I32   pair_nrc;
-
-  /*! Triplet production flag. If set to 0 (the default), triplet events
-    will be simulated as pair events. If set to 1, triplet event will
-    be explicitely simulated using the Borsellino cross section
-
-    Can be set in the input file using
-    \verbatim
-    Triplet production= On or Off
-    \endverbatim
-  */
-  EGS_I32   itriplet;
-
-  /*! Flag for radiative corrections for Compton scattering.
-      If set to 0 (the default), Compton scattering is modelled according
-      to Klein-Nishina or RIA, depending on ibcmp. If set to 1 and
-      rad_compton.mortran is compiled with the other EGSnrc mortran sources,
-      radiative corrections are taken into account in next-to-leading
-      order.
+    /*! Determines the angular distribution of bremstrahlung. If set to
+      2, Eq. 2BS of the review article by Koch and Motz will be used. If set
+      to 1, the leading term of 2BS will be used (the default).
+      If set to zero, the photons
+      will inherit the direction of the electron so that the user can
+      implement their own angular distribution by calling \c %ausgab() after
+      the bremsstrahlung event and setting the angles of the photons.
 
       Can be set in the input file using
       \verbatim
-      Radiative Compton corrections= On or Off
+      Brems angular sampling= Simple or KM
       \endverbatim
-                    */
-  EGS_I32   radc_flag;
+    */
+    EGS_I32   ibrdst;
 
-  /*! Electron impact ionization (EII) flag. If set to 0 (the default),
-   no EII occurs. If set to 1, EII is simulated using cross sections
-   based on unpublished work by Kawrakow
+    /*! Determines the angular distribution of pair particles. If set to 2,
+      the Schiff formula will be used (Eq. 3D-2003 of the review article by
+      Motz, Olsen and Koch), if set to 1 the leading term of the Schiff formula
+      will be used (the default), if set to 0 the original EGS4 approach
+      of polar angle = ratio of rest energy to total energy is employed.
 
-    Can be set in the input file using
-    \verbatim
-    Electron Impact Ionization= On or Off
-    \endverbatim
-   */
-  EGS_I32   eii_flag;
+      Can be set in the input file using
+      \verbatim
+      Pair angular sampling= Off or Simple or KM
+      \endverbatim
+    */
+    EGS_I32   iprdst;
+
+    /*! Determines the bremsstrahlung cross sections differential in the
+      photon energy to be used for sampling the photon energy.
+      If set to 0, the Bethe-Heitler high energy approximation will be
+      used. If set to 1, the NIST tabulations provided by Steve Seltzer
+      will be employed. If set to 2, the NRC brems data will be used,
+      which is a modified version of the NIST data with corrected
+      electron-electron brems contributions. Default is 0.
+
+      Can be set in the input file using
+      \verbatim
+      Brems cross sections= BH or NIST or NRC
+      \endverbatim
+    */
+    EGS_I32   ibr_nist;
+
+    /*! Determines if spin effects will be taken into account in electron
+      and positron elastic scattering (1=yes, the default, 0=no)
+
+      Can be set in the input file using
+      \verbatim
+      Spin effects= On or Off
+      \endverbatim
+     */
+    EGS_I32   spin_effects;
+
+    /*! Bound Compton scattering flag. If set to 0, Compton scattering will
+      be modeled according to Klein-Nishina, if set to 1 (the default),
+      Compton scattering will be modeled according to the relativistic
+      impulse approximation that takes into account binding and
+      Doppler broadenning.
+
+      Can be set in the input file using
+      \verbatim
+      Bound Compton scattering= On or Off
+      \endverbatim
+    */
+    EGS_I32   ibcmp;
+
+    /*! Reyleigh scattering flag. If set to 0 (the default), no
+      Reyleigh scattering will be done. Note that if you turn on
+      Reyleigh scattering by setting this flag to 1, all PEGS4 data
+      sets must include Reyleigh data
+
+      Can be set in the input file using
+      \verbatim
+      Reyleigh scattering= On or Off
+      \endverbatim
+    */
+    EGS_I32 iraylr;
+
+    /*! Atomic relaxations flag. If set to 1 (the default), vacancies
+     created in shells with binding energies above 1 keV will be relaxed
+     by fluorescent, Auger and Coster-Kronig transitions. Vacancies
+     can be currently created after photo-absorption, bound Compton scattering
+     and electron inelastic scattering (if eii_flag is not 0).
+     If set to 0, the binding energy will be given to the photo-electron
+     or deposited locally.
+     */
+    EGS_I32   iedgfl;
+
+    /*! Determines the angular distribution of photo-electrons. If set to
+      1 (the default), the angle of photo-electrons will be sampled from
+      the Sauter distribution. If set to 0, photo-electrons inherit the
+      direction of the incident photon.
+
+      Can be set in the input file using
+      \verbatim
+      Atomic relaxations= On or Off
+      \endverbatim
+    */
+    EGS_I32   iphter;
+
+    /*! Pair cross sections flag. If set to 0 (the default), the energy
+      of the pair particles will be sampled from the first Born approximation
+      cross section in its high-energy appoximation derived by Bethe-Heitler.
+      If set to 1, energies will be sampled from the NRC tabulations
+      based on the exact cross sections (tabulations are available
+      up to 85 MeV, above 85 MeV the Bethe-Heitler cross sections are
+      very close to the exact cross sections).
+
+      Can be set in the input file using
+      \verbatim
+      Pair cross sections= BH or NRC
+      \endverbatim
+    */
+    EGS_I32   pair_nrc;
+
+    /*! Triplet production flag. If set to 0 (the default), triplet events
+      will be simulated as pair events. If set to 1, triplet event will
+      be explicitely simulated using the Borsellino cross section
+
+      Can be set in the input file using
+      \verbatim
+      Triplet production= On or Off
+      \endverbatim
+    */
+    EGS_I32   itriplet;
+
+    /*! Flag for radiative corrections for Compton scattering.
+        If set to 0 (the default), Compton scattering is modelled according
+        to Klein-Nishina or RIA, depending on ibcmp. If set to 1 and
+        rad_compton.mortran is compiled with the other EGSnrc mortran sources,
+        radiative corrections are taken into account in next-to-leading
+        order.
+
+        Can be set in the input file using
+        \verbatim
+        Radiative Compton corrections= On or Off
+        \endverbatim
+                      */
+    EGS_I32   radc_flag;
+
+    /*! Electron impact ionization (EII) flag. If set to 0 (the default),
+     no EII occurs. If set to 1, EII is simulated using cross sections
+     based on unpublished work by Kawrakow
+
+      Can be set in the input file using
+      \verbatim
+      Electron Impact Ionization= On or Off
+      \endverbatim
+     */
+    EGS_I32   eii_flag;
 
     /*! Photonuclear attenuation flag. OFF if set to 0 (the default).
 
@@ -546,12 +546,12 @@ struct EGS_XOptions {
     \verbatim
     Photonuclear attenuation= On or Off
     \endverbatim
-  */
-  EGS_I32 iphotonuc;
+    */
+    EGS_I32 iphotonuc;
 
-  EGS_I32 eadl_relax;
+    EGS_I32 eadl_relax;
 
-  EGS_I32 mcdf_pe_xsections;
+    EGS_I32 mcdf_pe_xsections;
 
 };
 
@@ -623,6 +623,7 @@ struct EGS_IO {
     char pegs_file[256];
     char hen_house[128];
     char egs_home[128];
+    char output_dir[256];
     char work_dir[128];
     char host_name[64];
     EGS_I32 n_parallel, i_parallel, first_parallel, n_max_parallel,
@@ -639,7 +640,7 @@ struct EGS_IO {
 struct EGS_emfInputs {
     /*! Input values for static electric and magnetic fields */
     EGS_Float ExIN, EyIN, EzIN, EMLMTIN,
-    BxIN, ByIN, BzIN, Bx, By, Bz, Bx_new, By_new, Bz_new;
+              BxIN, ByIN, BzIN, Bx, By, Bz, Bx_new, By_new, Bz_new;
     bool emfield_on;
 };
 

--- a/HEN_HOUSE/pieces/help_message
+++ b/HEN_HOUSE/pieces/help_message
@@ -4,10 +4,16 @@ where [args] is one or more of the following arguments:
  -h or --help                 Print this message and exit.
 
  -i or --input ifile          Specifies that the input file is ifile.egsinp.
+                              Input lookup order is:
+                              * ./ifile.egsinp
+                              * $EGS_HOME/user_code/ifile.egsinp
 
  -o or --output ofile         Output data will be written to ofile.egslog,
                               ofile.egslst, etc., instead of ifile.egslog,
                               ifile.egslst, etc.
+
+ -d or --output-dir dir       Put output files and temporary egsrun_*
+                              directories in dir.
 
  -p or --pegs-file file_name  Use the pegs4 data file file_name.pegs4dat.
                               The system will look for it in the HEN_HOUSE

--- a/HEN_HOUSE/scripts/bin/egs-parallel
+++ b/HEN_HOUSE/scripts/bin/egs-parallel
@@ -53,6 +53,13 @@ function help {
 
         $(basename $0) --batch cpu -q short -n12 -v -c 'egs_chamber -i slab -p 521icru'
 
+    notes:
+
+        The run command should include -i/--input.
+        If the run command includes -d/--output-dir, job logs/lock files are
+        managed in that directory. Otherwise they are managed beside the
+        resolved input file (current/path first, then \$EGS_HOME/app fallback).
+
 EOF
 }
 
@@ -168,16 +175,19 @@ fi
 ### check run command and its arguments for input file and first job index
 set -- $opt_cmd
 cmd_app=$1
+cmd_app_name=$(basename "$cmd_app")
 cmd_input=""
 cmd_first="1"
+cmd_outdir=""
 if ! [ -x "$(command -v $cmd_app)" ]; then
     quit $LINENO "no such egsnrc executable found: $cmd_app"
 fi
 while [[ "$#" -gt 0 ]]; do
     opt=$1; shift
     case $opt in
-        -i) arg=$1; cmd_input=$1; shift;;
-        -f) arg=$1; cmd_first=$1; shift;;
+        -i|--input) arg=$1; cmd_input=$1; shift;;
+        -f|--first-job) arg=$1; cmd_first=$1; shift;;
+        -d|--output-dir) arg=$1; cmd_outdir=$1; shift;;
         *)  arg="skip";;
     esac
     if [ -z "$arg" ] || [ "${arg:0:1}" = "-" ]; then
@@ -198,24 +208,47 @@ fi
 ### set simulation basename from input file
 basename="$(basename "$cmd_input" .egsinp)"
 
-### check that the egs input file exists and is readable
-egsinp=$egs_home/$cmd_app/$basename.egsinp
-if ! [ -r $egsinp ]; then
-    quit $LINENO "cannot access input file: $egsinp.egsinp"
+### resolve input file path: local/path first, then EGS_HOME/app fallback
+if [ "${cmd_input##*/}" != "$cmd_input" ] || [ "${cmd_input##*\\}" != "$cmd_input" ]; then
+    has_path="yes"
+else
+    has_path="no"
+fi
+if [[ "$cmd_input" == *.egsinp ]]; then
+    input_arg="$cmd_input"
+else
+    input_arg="${cmd_input}.egsinp"
+fi
+if [ -r "$input_arg" ]; then
+    egsinp="$input_arg"
+elif [ "$has_path" = "no" ] && [ -r "$egs_home/$cmd_app_name/$input_arg" ]; then
+    egsinp="$egs_home/$cmd_app_name/$input_arg"
+else
+    quit $LINENO "cannot access input file: $input_arg"
+fi
+
+### determine run directory for lock/egsjob/log files
+if [ -n "$cmd_outdir" ]; then
+    run_dir="$cmd_outdir"
+else
+    run_dir="$(dirname "$egsinp")"
+fi
+if ! [ -d "$run_dir" ]; then
+    /bin/mkdir -p "$run_dir" || quit $LINENO "cannot create run directory: $run_dir"
 fi
 
 ### prevent the run if lock file or egsjob file present (unless forced)
 if [ "$opt_force" == "no" ]; then
 
     # check lock file
-    lock=$egs_home/$cmd_app/$basename.lock
+    lock=$run_dir/$basename.lock
     if [ -e $lock ]; then
         log "existing lock file: $lock"
         quit $LINENO "prevent erasing lock file (override with --force)"
     fi
 
     # check egsjob file
-    egsjob=$egs_home/$cmd_app/$basename.egsjob
+    egsjob=$run_dir/$basename.egsjob
     if [ -e $egsjob ]; then
         log  "existing egsjob file: $egsjob"
         quit $LINENO "prevent erasing egsjob file (override with --force)"
@@ -232,17 +265,19 @@ log "    delay      = $opt_delay"
 log "    command    = $opt_cmd"
 log "    basename   = $basename"
 log "    first job  = $cmd_first"
+log "    input file = $egsinp"
+log "    run dir    = $run_dir"
 log "    options    = $opt_options"
 
-### redirect egs-parallel log file to application directory
-logfile=$egs_home/$cmd_app/$basename.egsparallel
+### redirect egs-parallel log file to run directory
+logfile=$run_dir/$basename.egsparallel
 /bin/mv egs-parallel-$$.log $logfile
 exec 3>>$logfile
 log "log file: $logfile"
 
-### go to egs application directory
-log "cd $egs_home/$cmd_app"
-cd $egs_home/$cmd_app
+### go to run directory
+log "cd $run_dir"
+cd "$run_dir"
 
 ### log script specific for this batch system
 log "EXEC egs-parallel-$opt_batch $opt_queue $opt_nthread $opt_delay $cmd_first $basename '$opt_cmd' '$opt_options' $verbosity"

--- a/HEN_HOUSE/scripts/configure_c++
+++ b/HEN_HOUSE/scripts/configure_c++
@@ -212,7 +212,7 @@ case $canonical_system in
     *-*-darwin*)
         is_osx=yes;
         libext=".dylib"; libext_bundle=".so"; defines="-DOSX";
-        lib_link1="-L\$(abs_dso)"; shared="-dynamiclib";
+        lib_link1="-L\$(abs_dso) -Wl,-rpath,\$(abs_dso)"; shared="-dynamiclib";
         case $CXX in
             g++*) shared_bundle="-bundle" ;;
             *)   shared_bundle="-qmkshrobj" ;; # assume xlC

--- a/HEN_HOUSE/scripts/run_user_code
+++ b/HEN_HOUSE/scripts/run_user_code
@@ -38,14 +38,15 @@ my_name=`echo "$0" |sed 's,.*[\\/],,'`
 if test $# -lt 3; then
     cat >&2 <<EOF
 
-Usage: $my_name user_code input_file pegs_file [noopt] [config=xxx]
+Usage: $my_name user_code input_file pegs_file [noopt] [config=xxx] [outdir=dir]
 
 $my_name runs the user code user_code, using input_file as input file
 (use two double quotes if there is no input file needed) and pegs_file
 as pegs4 data file. The optional argument noopt tells the script to
 use the executable compiled without optimizations, using config=xxx
 you can use a configuration different from the one specified by the
-environment variable EGS_CONFIG.
+environment variable EGS_CONFIG. Use outdir=dir to override
+the default output directory (current working directory).
 
 EOF
     exit 1
@@ -57,6 +58,7 @@ pegs_file=$3
 egs_home="$EGS_HOME"
 egs_configuration="$EGS_CONFIG"
 what=
+run_output_dir=`pwd`
 
 if test "x$egs_home" = x; then
 
@@ -97,6 +99,7 @@ EOF
                  exit 1
                   ;;
       config=*)  egs_configuration=`echo $1 | sed 's/config=//'` ;;
+      outdir=*)  run_output_dir=`echo $1 | sed 's/outdir=//'` ;;
              *)  ;; #ignore everything else
 
     esac
@@ -190,18 +193,6 @@ if test ! -d "$egs_home"; then
 
 fi
 
-if test ! -d "$egs_home/$user_code"; then
-
-    echo "The directory '$egs_home/$user_code' dose not exist. Creating it." >&2
-    if { mkdir "$egs_home/$user_code"; status=$?; (exit $status); }; then
-       :
-    else
-       echo "Failed." >&2
-       exit 1
-    fi
-
-fi
-
 executable="$egs_home/bin/$my_machine/$user_code$what"
 
 if test ! -x $executable; then
@@ -213,9 +204,9 @@ if test ! -x $executable; then
 fi
 
 if test $pegs_file = "pegsless"; then
-    command="$executable"
+    command="$executable -d $run_output_dir"
 else
-    command="$executable -p $pegs_file"
+    command="$executable -p $pegs_file -d $run_output_dir"
 fi
 
 if test "x$input_file" = x; then

--- a/HEN_HOUSE/scripts/run_user_code_batch
+++ b/HEN_HOUSE/scripts/run_user_code_batch
@@ -59,7 +59,7 @@ my_name=`echo "$0" |sed 's,.*[\\/],,'`
 if test $# -lt 3; then
     cat >&2 <<EOF
 
-Usage: $my_name user_code input_file pegs_file [noopt] [config=xxx]
+Usage: $my_name user_code input_file pegs_file [noopt] [config=xxx] [outdir=dir]
                 [short|long|user1|user2|user3] [batch=batch_system] [p=N]
 
 $my_name runs the user code user_code, using input_file as input file
@@ -67,7 +67,8 @@ $my_name runs the user code user_code, using input_file as input file
 as pegs4 data file. The optional argument noopt tells the script to
 use the executable compiled without optimizations, using config=xxx
 you can use a configuration different from the one specified by the
-environment variable EGS_CONFIG.
+environment variable EGS_CONFIG. Use outdir=dir to override
+the default output directory (current working directory).
 
 One can also select the batch system by setting the batch variable
 on the command line and set the queue type (short,long,user1,user2,user3).
@@ -99,6 +100,7 @@ testing=no
 egs_batch_system=at
 fresh=yes
 rc_simple=
+run_output_dir=`pwd`
 if test "x$EGS_BATCH_SYSTEM" != x; then
     egs_batch_system="$EGS_BATCH_SYSTEM"
 fi
@@ -131,6 +133,7 @@ EOF
                  exit 1
                   ;;
       config=*)  egs_configuration=`echo $1 | sed 's/config=//'` ;;
+      outdir=*)  run_output_dir=`echo $1 | sed 's/outdir=//'` ;;
         simple)  rc_simple="-s" ;;
          short)  queue1=1 ;;
          user1)  queue1=2 ;;
@@ -267,18 +270,6 @@ if test ! -d "$egs_home"; then
 
 fi
 
-if test ! -d "$egs_home/$user_code"; then
-
-    echo "The directory '$egs_home/$user_code' dose not exist. Creating it." >&2
-    if { mkdir "$egs_home/$user_code"; status=$?; (exit $status); }; then
-       :
-    else
-       echo "Failed." >&2
-       exit 1
-    fi
-
-fi
-
 executable="$egs_home/bin/$my_machine/$user_code$what"
 
 if test ! -x $executable; then
@@ -299,7 +290,7 @@ if test "x$input_file" != x; then
     command="$command -i $input_file"
 fi
 
-command="$command -e $egs_home -H $hen_house $rc_simple"
+command="$command -e $egs_home -H $hen_house -d $run_output_dir $rc_simple"
 
 # export the important environent variables just in case.
 # note the -x option for nqs, which exports the environment of the

--- a/HEN_HOUSE/specs/egspp_libs.spec
+++ b/HEN_HOUSE/specs/egspp_libs.spec
@@ -34,7 +34,7 @@ ifeq ($(MACOSX),yes)
 
 all: $(DSO2)$(libpre)$(library)$(libext) $(DSO2)$(libpre)$(library)$(libext_bundle)
 
-macos_dylib_id = -Wl,-install_name,@loader_path/$(libpre)$(library)$(libext)
+macos_dylib_id = -Wl,-install_name,@rpath/$(libpre)$(library)$(libext)
 
 $(DSO2)$(libpre)$(library)$(libext_bundle): $(lib_objects)
 	$(CXX) $(INC2) $(DEFS) $(opt) $(shared_bundle) $(lib_link1) $(lib_objects) $(extra) $(lib_link2)

--- a/HEN_HOUSE/specs/egspp_libs.spec
+++ b/HEN_HOUSE/specs/egspp_libs.spec
@@ -34,13 +34,19 @@ ifeq ($(MACOSX),yes)
 
 all: $(DSO2)$(libpre)$(library)$(libext) $(DSO2)$(libpre)$(library)$(libext_bundle)
 
+macos_dylib_id = -Wl,-install_name,@loader_path/$(libpre)$(library)$(libext)
+
 $(DSO2)$(libpre)$(library)$(libext_bundle): $(lib_objects)
 	$(CXX) $(INC2) $(DEFS) $(opt) $(shared_bundle) $(lib_link1) $(lib_objects) $(extra) $(lib_link2)
 
 endif
 
 $(DSO2)$(libpre)$(library)$(libext): $(lib_objects)
+ifeq ($(MACOSX),yes)
+	$(CXX) $(INC2) $(DEFS) $(opt) $(shared) $(lib_link1) $(lib_objects) $(macos_dylib_id) $(extra) $(lib_link2)
+else
 	$(CXX) $(INC2) $(DEFS) $(opt) $(shared) $(lib_link1) $(lib_objects) $(extra) $(lib_link2)
+endif
 
 $(lib_objects): $(common_h2) $(extra_dep)
 

--- a/HEN_HOUSE/specs/egspp_osx_example.conf
+++ b/HEN_HOUSE/specs/egspp_osx_example.conf
@@ -97,8 +97,10 @@ EOUT = -o
 # Linking against the geometry (and possible other) DSO(s)
 # -L$(abs_dso) tells the linker to look in
 # $HEN_HOUSE/egs++/dso/$my_machine for the egspp library.
+# -Wl,-rpath,$(abs_dso) embeds that path so @rpath install names resolve
+# when user-code executables in $EGS_HOME/bin/$my_machine link egs++ DSOs.
 #
-lib_link1 = -L$(abs_dso)
+lib_link1 = -L$(abs_dso) -Wl,-rpath,$(abs_dso)
 link2_prefix = -l
 link2_suffix =
 

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -78,6 +78,10 @@ REPLACE {;COMIN/my_times/;} WITH {;
 "                                    ofile.egslog, ofile.egslst, etc., instead
 "                                    of ifile.egslog, etc.
 "
+"       -d or --output-dir dir       Put output files and egsrun_* temporary
+"                                    directories in dir instead of the default
+"                                    output location.
+"
 "       -H or --hen-house dir        Change the HEN_HOUSE to be dir instead
 "                                    of the directory specified in the
 "                                    machine.macros file.
@@ -144,8 +148,9 @@ REPLACE {;COMIN/my_times/;} WITH {;
 "     See note below on how $HEN_HOUSE and $EGS_HOME are determined
 "
 "  2. If a -i ifile option was given as argument, ifile.egsinp is
-"     opened as fortran unit 5.
-"     The input file MUST be in the user code directory on $EGS_HOME
+"     opened as fortran unit 5. The lookup order is:
+"       - ifile.egsinp in the current working directory
+"       - $EGS_HOME/user_code/ifile.egsinp
 "
 "  3. If the run is a batch run (the -b option was present on the command
 "     line), fortran unit 6 is connected to an output file with a .egslog
@@ -214,9 +219,11 @@ implicit none;
 integer   l, lnblnk1, l1, l2;
 integer   i;
 character arg*256,tmp_string*512, tmp1_string*512, ucode_dir*512,
+          tmp2_string*512, base_input*512,
           line*80,
           line1*80,dattim*24;
-$LOGICAL  have_input,egs_isdir,egs_strip_extension,ex,
+$LOGICAL  have_input,egs_isdir,egs_strip_extension,ex,has_path,
+          egs_is_absolute_path,
           on_egs_home,is_opened;
 $INTEGER  mypid;
 integer   getpid;
@@ -353,24 +360,86 @@ $open_data_file(tmp_string,tmp1_string,'photo_relax.data',$PHOTOUNIT);
 
 $set_string(ucode_dir,' ');
 ucode_dir = $cstring(egs_home) // $cstring(user_code) // $file_sep;
+IF( lnblnk1(output_dir) > 0 ) [
+    DO i=1,lnblnk1(output_dir) [
+        IF( output_dir(i:i) = '/' ) [
+            output_dir(i:i) = $file_sep;
+        ]
+    ]
+    l = lnblnk1(output_dir);
+    IF( output_dir(l:l) ~= $file_sep ) output_dir(l+1:l+1) = $file_sep;
+]
 
 have_input = .false.;
 i_input=5;
 IF( lnblnk1(input_file) > 0 ) [
     have_input = .true.;
-    l = lnblnk1(egs_home); l1 = lnblnk1(user_code)+1;
-    l2 = lnblnk1(input_file) + lnblnk1('.egsinp');
-    IF( l + l1 + l2 > 1024 ) [
-        $egs_fatal(*,'input file name (including path) is too long ',l+l1+l2);
+    $set_string(base_input,' ');
+    base_input = $cstring(input_file);
+    ex = egs_strip_extension(base_input,'.egsinp');
+    has_path = .false.;
+    DO i=1,lnblnk1(base_input) [
+        IF( base_input(i:i) = '/' | base_input(i:i) = $file_sep ) [
+            has_path = .true.;
+            EXIT;
+        ]
     ]
-    ex = egs_strip_extension(input_file,'.egsinp');
-    tmp_string = $cstring(ucode_dir) // $cstring(input_file) // '.egsinp';
+    l2 = lnblnk1(base_input) + lnblnk1('.egsinp');
+    IF( l2 > 1024 ) [
+        $egs_fatal(*,'input file name (including path) is too long ',l2);
+    ]
+    tmp_string = $cstring(base_input) // '.egsinp';
     inquire(file=tmp_string,exist=ex);
+    IF( ~ex ) [
+        IF( egs_is_absolute_path(base_input) | has_path ) [
+            $egs_fatal(*,'Input file ',$cstring(tmp_string),' does not exist.');
+        ]
+        l = lnblnk1(egs_home); l1 = lnblnk1(user_code)+1;
+        l2 = lnblnk1(base_input) + lnblnk1('.egsinp');
+        IF( l + l1 + l2 > 1024 ) [
+            l = l + l1 + l2;
+            $egs_fatal(*,'input file name (including path) is too long ',l);
+        ]
+        tmp_string = $cstring(ucode_dir) // $cstring(base_input) // '.egsinp';
+        inquire(file=tmp_string,exist=ex);
+    ]
     IF( ~ex ) [
         $egs_fatal(*,'Input file ',$cstring(tmp_string),' does not exist.');
     ]
+    $set_string(tmp2_string,' ');
+    tmp2_string = $cstring(tmp_string);
+    DO i=lnblnk1(tmp2_string),1,-1 [
+        IF( tmp2_string(i:i) = $file_sep | tmp2_string(i:i) = '/' ) [
+            IF( lnblnk1(output_dir) = 0 ) [
+                output_dir = tmp2_string(:i);
+            ]
+            EXIT;
+        ]
+    ]
+    call egs_strip_path(base_input);
+    input_file = $cstring(base_input);
     $AVAILABLE_UNIT(i_input,tmp_string);
     open(i_input,file=tmp_string,status='old',err=:open_input_error:);
+]
+
+IF( lnblnk1(output_file) = 0 ) [
+    IF( have_input ) [
+        output_file = $cstring(input_file);
+    ]
+    ELSE [
+        output_file = 'test';
+    ]
+]
+IF( lnblnk1(output_dir) = 0 ) output_dir = '.' // $file_sep;
+ex = egs_isdir(output_dir);
+IF( ~ex ) [
+    tmp1_string = 'mkdir -p ' // $cstring(output_dir);
+    l = lnblnk1(tmp1_string); tmp1_string(l+1:l+1) = char(0);
+    istat = egs_system(tmp1_string);
+    IF( istat ~= 0 ) [
+        $egs_fatal(*,'failed to create output directory ',
+                   $cstring(output_dir));
+    ]
 ]
 
 " Construct a temporary directory name to run from "
@@ -388,7 +457,7 @@ ELSE [
                $file_sep;
 ]
 $set_string(tmp_string,' ');
-tmp_string = $cstring(ucode_dir) // $cstring(work_dir);
+tmp_string = $cstring(output_dir) // $cstring(work_dir);
 DO i=1,lnblnk1(tmp_string) [
     IF( tmp_string(i:i) = '/' ) [
         tmp_string(i:i) = $file_sep;
@@ -654,13 +723,18 @@ IF( have_arg ) [
     ]
     output_file(:l) = $cstring(arg);
 ]
-ELSE [
-    IF( lnblnk1(input_file) > 0 ) [
-        output_file(:lnblnk1(input_file)) = $cstring(input_file);
+
+" Check for an output directory option "
+$check_get_argument('-d','--output-dir',arg);
+IF( have_arg ) [
+    l = lnblnk1(arg);
+    IF( l = 0 ) [
+        $egs_fatal('(a)',' empty argument after -d');
     ]
-    ELSE [
-        output_file = 'test';
+    IF( l > 254 ) [
+        $egs_fatal(*,'output directory argument is too long ',l);
     ]
+    output_dir(:l) = $cstring(arg);
 ]
 
 return; end;
@@ -688,10 +762,10 @@ $declare_write_buffer;
 $set_string(tmp_string,' '); $set_string(ucode_dir,' ');
 ucode_dir = $cstring(egs_home) // $cstring(user_code) // $file_sep;
 IF( flag ) [
-    tmp_string = $cstring(ucode_dir) // $cstring(work_dir);
+    tmp_string = $cstring(output_dir) // $cstring(work_dir);
 ]
 ELSE [
-    tmp_string = $cstring(ucode_dir);
+    tmp_string = $cstring(output_dir);
 ]
 
 tmp_string = $cstring(tmp_string) // $cstring(output_file);
@@ -811,7 +885,7 @@ $egs_info('(//a,t56,a,/,a)','End of run ',dattim,line);
 " Close all I/O units "
 n_open=0;
 $set_string(base,' ');
-base = $cstring(egs_home) // $cstring(user_code);
+base = $cstring(output_dir);
 DO i=1,$max_unit [
     IF( is_batch | i ~= i_log ) [
       inquire(i,opened=is_open);
@@ -832,8 +906,7 @@ IF( lnblnk1(work_dir) = 0 ) [ return; ]
 " Now generate a junk file in the working directory so that the move "
 " command does not fail in case there are no files "
 $set_string(base,' ');
-base = $cstring(egs_home) // $cstring(user_code) // $file_sep //
-        $cstring(work_dir);
+base = $cstring(output_dir) // $cstring(work_dir);
 DO i=1,lnblnk1(base) [
     IF( base(i:i) = '/' ) [
         base(i:i) = $file_sep;
@@ -856,9 +929,8 @@ IF( egs_isdir(base) ) [
 
     " Move all files from the working directory to the user code directory "
     $set_string(base1,' ');
-    base = $cstring(egs_home) // $cstring(user_code) // $file_sep //
-            $cstring(work_dir);
-    base1 = $cstring(egs_home) // $cstring(user_code);
+    base = $cstring(output_dir) // $cstring(work_dir);
+    base1 = $cstring(output_dir);
     $set_string(tmp_string,' ');
     tmp_string = $move_file // $cstring(base) // '*  ' // $cstring(base1);
     l = lnblnk1(tmp_string)+1;
@@ -887,7 +959,7 @@ IF( egs_isdir(base) ) [
 ]
 
 " Now set work_dir to blank so that all I/O stuff after egs_finish ends up"
-" in the user code directory "
+" in the output directory "
 $set_string(work_dir,' ');
 
 return; end;
@@ -994,6 +1066,7 @@ IF( $file_sep ~= fool_dec ) [
 IF( i > 0 & egs_home(i:i) ~= $file_sep ) egs_home(i+1:i+1) = $file_sep;
 $set_string(input_file,' ');
 $set_string(output_file,' ');
+$set_string(output_dir,' ');
 $set_string(work_dir,' ');
 $set_string(pegs_file,' ');
 $set_string(host_name,' ');
@@ -1026,16 +1099,16 @@ urcSleep          = $URC-SLEEP;    "Set to 1 s in egsnrc.macros"
 urcCheckIntervals = $URC-INTERVALS;"Set to 1 in egsnrc.macros"
 
 $set_string(base,' ');
-base = $cstring(egs_home) // $cstring(user_code) // $file_sep //
+base = $cstring(output_dir) //
        $cstring(output_file) // '_w';
 
 "the following is to count the number of output files from"
 "a parallel run"
 $set_string(base1,' ');
-base1 = $cstring(egs_home) // $cstring(user_code) // $file_sep //
+base1 = $cstring(output_dir) //
        $cstring(output_file) // '_w*' // $cstring(extension);
 $set_string(outfile,' ');
-outfile = $cstring(egs_home) // $cstring(user_code) // $file_sep //
+outfile = $cstring(output_dir) //
        'parfiles_tmp';
 
 :check-output-files:;
@@ -1227,8 +1300,8 @@ IF( egs_is_absolute_path(extension) ) [
 ]
 
 $set_string(tmp_string,' ');
-tmp_string = $cstring(egs_home) // $cstring(user_code) // $file_sep //
-             $cstring(work_dir) // $cstring(output_file);
+tmp_string = $cstring(output_dir) // $cstring(work_dir);
+tmp_string = $cstring(tmp_string) // $cstring(output_file);
 IF( i_parallel > 0 ) [
     tmp_string = $cstring(tmp_string) // '_w';
     call egs_itostring(tmp_string,i_parallel,.false.);
@@ -1278,8 +1351,8 @@ integer  function egs_open_datfile(iunit,rl,action,extension);
 " The algorithm for searching for the file is as follows:
 "  1. If extension is an absolute file name (including path),
 "     try opening this file, else
-"  2. Try output_file.extension in the user code directory.
-"  3. Try input_file.extension in the user code directory (if input_file is
+"  2. Try output_file.extension in the output directory.
+"  3. Try input_file.extension in the output directory (if input_file is
 "     different from output_file).
 " If the file is found, open it using status='old' for
 "   a) formatted sequential access, if rl=0
@@ -1328,7 +1401,7 @@ IF( egs_is_absolute_path(extension) ) [
 ]
 
 $set_string(base,' '); $set_string(fn,' ');
-base = $cstring(egs_home) // $cstring(user_code) // $file_sep;
+base = $cstring(output_dir);
 "fn = $cstring(base) // $cstring(output_file) // $cstring(extension);"
 IF( i_parallel > 0 ) [
     fn = $cstring(base) // $cstring(output_file) // '_w';

--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -3617,6 +3617,7 @@ REPLACE {;COMIN/EGS-IO/;} WITH {;
                   pegs_file,  "The pegs file name with path and extension"
                   hen_house,  "The HEN_HOUSE directory"
                   egs_home,   "The EGS_HOME directory"
+                  output_dir, "The output directory for run artifacts"
                   work_dir,   "The working directory within the user code dir."
                   host_name,  "The name of the host"
                   n_parallel, "if >0, number of parallel jobs"
@@ -3638,7 +3639,8 @@ REPLACE {;COMIN/EGS-IO/;} WITH {;
                   is_pegsless;    "true if you are running without pegs file"
   character input_file*256, output_file*256, pegs_file*256,
             file_extensions*$max_extension_length,
-            hen_house*128, egs_home*128, work_dir*128, user_code*64,
+            hen_house*128, egs_home*128, output_dir*256,
+            work_dir*128, user_code*64,
             host_name*64;
   $INTEGER  n_parallel, i_parallel, first_parallel,n_max_parallel,
             n_chunk, file_units, n_files,i_input,i_log,i_incoh,

--- a/docs/nrc-cnrc-upstream.md
+++ b/docs/nrc-cnrc-upstream.md
@@ -42,24 +42,26 @@ git fetch mchamberland-pr
 - Write run artifacts next to the input (or under `-d` / `--output-dir`)
 - Wrapper and Qt GUI updates; macOS `@loader_path` for egs++ dylibs
 
-This branch contains **only the five `#1212` commits** cherry-picked onto `egs_brachy` (not a full merge of `mchamberland-pr/run-anywhere`, which would pull unrelated `develop` history and conflict heavily).
+This branch contains the **functional `#1212` commits** cherry-picked onto `egs_brachy` (not a full merge of `mchamberland-pr/run-anywhere`). For day-to-day testing, **`dev`** is usually easier — it also has #934 and the scratch smoke test. See [branch-layout.md](branch-layout.md) on the `dev` branch.
 
 Cherry-picked commits (oldest first):
 
-1. `5c7b7db3` — Mortran core
-2. `84a672ee` — egs++
-3. `c8159a9d` — wrapper scripts
-4. `613eaa0f` — egs_gui
-5. `a1d5a4b8` — `@loader_path` dylibs
+1. `d21384cb` — Mortran core
+2. `80bceafe` — egs++
+3. `101392de` — wrapper scripts
+4. `6a1dfee3` — egs_gui
+5. `5f0822d4` — `@loader_path` dylibs
+6. `20f5a44d` — `@rpath` install names + embedded DSO rpath (macOS)
+7. `a629de6a` — JCF `.lock` / uniform RCO paths via `getOutputDir()` (matches [nrc-cnrc/EGSnrc#1399](https://github.com/nrc-cnrc/EGSnrc/pull/1399) commit `3ce3e860`)
 
 ### Local development
 
-Use this branch as the EGSnrc-eb base when you want run-anywhere for testing (e.g. eb_tests from any directory):
+Prefer **`dev`** for run-anywhere + #934 testing. Use this `nrc/*` branch for upstream-tracking or if you need the minimal cherry-pick set on `egs_brachy` only:
 
 ```bash
-cd /path/to/EGSnrc-eb
+git checkout dev                    # recommended
+# or:
 git checkout nrc/run-anywhere-pr1399
-# configure / build when ready — see main README
 ```
 
 Combine with egs_brachy feature work by checking out the submodule branch you need; the submodule pointer is independent of the EGSnrc core branch.

--- a/docs/nrc-cnrc-upstream.md
+++ b/docs/nrc-cnrc-upstream.md
@@ -1,5 +1,10 @@
 # nrc-cnrc upstream integration (EGSnrc-eb)
 
+> **DO NOT MERGE** branches named `nrc/*` into `egs_brachy`. They carry pre-merge
+> [nrc-cnrc/EGSnrc](https://github.com/nrc-cnrc/EGSnrc) changes for local dev only.
+> When upstream merges the corresponding PR, reconcile via `nrc/develop` and delete
+> the `nrc/*` branch. See [nrc/run-anywhere-pr1399](#nrcrun-anywhere-pr1399) below.
+
 This fork tracks [clrp-code/EGSnrc_CLRP](https://github.com/clrp-code/EGSnrc_CLRP) on branch `egs_brachy`, with `nrc` pointing at [nrc-cnrc/EGSnrc](https://github.com/nrc-cnrc/EGSnrc).
 
 Some NRC changes land on `develop` before we merge them into CLRP. For features still in open PRs, we carry them on dedicated **`nrc/*` branches** so day-to-day CLRP work stays clean.

--- a/docs/nrc-cnrc-upstream.md
+++ b/docs/nrc-cnrc-upstream.md
@@ -1,0 +1,111 @@
+# nrc-cnrc upstream integration (EGSnrc-eb)
+
+This fork tracks [clrp-code/EGSnrc_CLRP](https://github.com/clrp-code/EGSnrc_CLRP) on branch `egs_brachy`, with `nrc` pointing at [nrc-cnrc/EGSnrc](https://github.com/nrc-cnrc/EGSnrc).
+
+Some NRC changes land on `develop` before we merge them into CLRP. For features still in open PRs, we carry them on dedicated **`nrc/*` branches** so day-to-day CLRP work stays clean.
+
+## Remotes
+
+| Remote | Repository | Use |
+|--------|------------|-----|
+| `clrp` | clrp-code/EGSnrc_CLRP | CLRP fork; push target |
+| `nrc` | nrc-cnrc/EGSnrc | Official upstream |
+| `mchamberland-pr` | mchamberland/EGSnrc | Open NRC PR branches (optional) |
+
+Add the PR author remote once:
+
+```bash
+git remote add mchamberland-pr https://github.com/mchamberland/EGSnrc.git
+git fetch mchamberland-pr
+```
+
+## Branch layout
+
+| Branch | Purpose |
+|--------|---------|
+| `egs_brachy` | Main CLRP line; tracks `clrp/egs_brachy` |
+| `nrc/run-anywhere-pr1399` | Pre-merge [nrc-cnrc/EGSnrc#1399](https://github.com/nrc-cnrc/EGSnrc/pull/1399) (run-anywhere I/O) |
+| `feature/*` | CLRP feature work (may update the egs_brachy submodule) |
+
+**egs_brachy** itself is a submodule at `HEN_HOUSE/user_codes/egs_brachy` with its own branches.
+
+## nrc/run-anywhere-pr1399
+
+[PR #1399](https://github.com/nrc-cnrc/EGSnrc/pull/1399) adds run-anywhere behaviour:
+
+- Resolve bare input names from the **current directory first**, then `$EGS_HOME/<user_code>/`
+- Write run artifacts next to the input (or under `-d` / `--output-dir`)
+- Wrapper and Qt GUI updates; macOS `@loader_path` for egs++ dylibs
+
+This branch contains **only the five `#1212` commits** cherry-picked onto `egs_brachy` (not a full merge of `mchamberland-pr/run-anywhere`, which would pull unrelated `develop` history and conflict heavily).
+
+Cherry-picked commits (oldest first):
+
+1. `5c7b7db3` — Mortran core
+2. `84a672ee` — egs++
+3. `c8159a9d` — wrapper scripts
+4. `613eaa0f` — egs_gui
+5. `a1d5a4b8` — `@loader_path` dylibs
+
+### Local development
+
+Use this branch as the EGSnrc-eb base when you want run-anywhere for testing (e.g. eb_tests from any directory):
+
+```bash
+cd /path/to/EGSnrc-eb
+git checkout nrc/run-anywhere-pr1399
+# configure / build when ready — see main README
+```
+
+Combine with egs_brachy feature work by checking out the submodule branch you need; the submodule pointer is independent of the EGSnrc core branch.
+
+Example: source-coordinate-transform work
+
+```bash
+# EGSnrc core with run-anywhere
+git checkout nrc/run-anywhere-pr1399
+
+# egs_brachy feature (submodule)
+cd HEN_HOUSE/user_codes/egs_brachy
+git checkout feature/source-coordinate-transform
+```
+
+### When upstream merges PR #1399
+
+1. Fetch official upstream:
+   ```bash
+   git fetch nrc develop
+   ```
+2. Merge into CLRP main line:
+   ```bash
+   git checkout egs_brachy
+   git merge nrc/develop
+   ```
+3. Reconcile `nrc/run-anywhere-pr1399`:
+   - If the merged patches match, delete the branch — it is redundant.
+   - If NRC squash-rebased, you may get conflicts in the same files; resolve by **preferring upstream** (`nrc/develop`).
+   - Optionally revert the cherry-pick range on `egs_brachy` before merging `nrc/develop` if git reports duplicate changes.
+
+This does **not** corrupt history permanently. Worst case: one-time merge conflicts in overlapping files (`egs_application.cpp`, scripts, etc.).
+
+### Do not
+
+- Merge `mchamberland-pr/run-anywhere` wholesale into `egs_brachy` (large conflict surface).
+- Mix nrc-cnrc cherry-picks and unrelated CLRP features in a single commit.
+- Assume PR branches stay rebased — re-fetch before adding more commits.
+
+## Refreshing an nrc/* branch
+
+```bash
+git fetch mchamberland-pr
+git checkout nrc/run-anywhere-pr1399
+git rebase egs_brachy   # after CLRP moves forward
+# If the PR was force-pushed, re-cherry-pick the five commits onto a fresh branch from egs_brachy
+```
+
+## Adding another pre-merge NRC PR
+
+1. Branch from `egs_brachy`: `git checkout -b nrc/<short-name>-pr<number> egs_brachy`
+2. Cherry-pick **only** the PR’s functional commits (inspect with `git log nrc/develop..<pr-branch>`).
+3. Document the branch in this file.
+4. When merged upstream, merge `nrc/develop` into `egs_brachy` and drop the `nrc/*` branch.


### PR DESCRIPTION
## DO NOT MERGE

This branch is **not** intended to merge into `egs_brachy`. It exists on the remote for backup and shared local development only.

It cherry-picks the functional commits from [nrc-cnrc/EGSnrc#1399](https://github.com/nrc-cnrc/EGSnrc/pull/1399) (run-anywhere I/O) onto `egs_brachy`.

When NRC merges PR #1399 into `develop`, reconcile by merging `nrc/develop` into `egs_brachy` and **delete this branch**. Do not merge this PR.

See `docs/nrc-cnrc-upstream.md` on this branch for the full workflow.

## Contents

* Mortran run-anywhere input/output paths
* egs++ application path handling
* Wrapper script updates (`run_user_code`, `egs-parallel`, etc.)
* egs_gui run-from-input-dir
* macOS `@rpath` for egs++ dylibs (replaces earlier `@loader_path`-only approach)
* JCF `.lock` and uniform RCO cleanup via `getOutputDir()` (matches upstream `3ce3e860`)
* Upstream integration documentation

For day-to-day testing, prefer branch **`dev`** (run-anywhere + #934 + scratch smoke test).

## Test plan

* Configure EGSnrc-eb from this branch
* Rebuild affected user codes (e.g. `egs_brachy`)
* Run eb_tests from a directory outside `$EGS_HOME`