### PR TITLE
Clean up egs++ startup log output.

### DIFF
--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -776,7 +776,6 @@ int EGS_Application::initRNG() {
         rndm = EGS_RandomGenerator::createRNG(input,sequence);
     }
     if (!rndm) {
-        egsWarning("EGS_Application::initRNG(): using default RNG\n");
         rndm = EGS_RandomGenerator::defaultRNG(sequence);
     }
     if (!rndm) {
@@ -788,9 +787,20 @@ int EGS_Application::initRNG() {
 
 int EGS_Application::initSimulation() {
     //if( !input ) { egsWarning("%s no input\n",__egs_app_msg2); return -1; }
-    egsInformation("In EGS_Application::initSimulation()\n");
     int err;
     bool ok = true;
+
+    err = initRunControl();
+    if (err) {
+        egsWarning("\n\n%s run control initialization failed\n",__egs_app_msg2);
+        return 1;
+    }
+    err = initEGSnrcBackEnd();
+    if (err) {
+        egsWarning("\n\n%s back-end initialization failed\n",__egs_app_msg2);
+        return 2;
+    }
+
     err = initGeometry();
     if (err) {
         egsWarning("\n\n%s geometry initialization failed\n",__egs_app_msg2);
@@ -806,18 +816,8 @@ int EGS_Application::initSimulation() {
         egsWarning("\n\n%s RNG initialization failed\n",__egs_app_msg2);
         ok = false;
     }
-    err = initRunControl();
-    if (err) {
-        egsWarning("\n\n%s run control initialization failed\n",__egs_app_msg2);
-        ok = false;
-    }
     if (!ok) {
         return 1;
-    }
-    err = initEGSnrcBackEnd();
-    if (err) {
-        egsWarning("\n\n%s back-end initialization failed\n",__egs_app_msg2);
-        return 2;
     }
     describeUserCode();
     err = initCrossSections();

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -295,13 +295,13 @@ public:
       the source, the random number generator, the run control object,
       the EGSnrc mortran back end, the cross sections and the scoring
       of quantities of interest by calling in succession the
-      protected virtual functions initGeometry(),
-      initSource(), initRNG(), initRunControl(), initEGSnrcBackEnd(),
-      initCrossSections() and initScoring().
+      protected virtual functions initRunControl(), initEGSnrcBackEnd(),
+      initGeometry(), initSource(), initRNG(), initCrossSections()
+      and initScoring().
       - If all calls succeed (i.e. the above functions return zero)
         the return value is zero.
-      - The return value is 1 if any of initGeometry(), initSource(),
-        initRNG() or initRunControl() returns a non-zero status,
+      - The return value is 1 if any of initRunControl(), initGeometry(),
+        initSource() or initRNG() returns a non-zero status,
       - 2 if initEGSnrcBackEnd() returns a non-zero status,
       - 3 if initCrossSections() returns a non-zero status  and
       - 4 if initScoring() returns a non-zero status.

--- a/HEN_HOUSE/egs++/egs_rndm.cpp
+++ b/HEN_HOUSE/egs++/egs_rndm.cpp
@@ -420,8 +420,6 @@ EGS_RandomGenerator *EGS_RandomGenerator::createRNG(EGS_Input *input,
     else {
         i = input->takeInputItem("rng definition");
         if (!i) {
-            egsWarning("EGS_RandomGenerator::createRNG: no 'RNG definition'"
-                       " input\n");
             return 0;
         }
         delete_it = true;


### PR DESCRIPTION
Initialize the Fortran back end before user-code messages, remove the initSimulation debug line, and silence benign default-RNG warnings. Bump egs_brachy for matching user-code log cleanup.